### PR TITLE
SystemUI: don't use hardcoded textSize in LocationTile

### DIFF
--- a/packages/SystemUI/res/layout/location.xml
+++ b/packages/SystemUI/res/layout/location.xml
@@ -49,7 +49,7 @@
             android:paddingLeft="@dimen/detail_radio_group_padding_left"
             android:paddingRight="@dimen/detail_radio_group_padding"
             android:paddingBottom="@dimen/detail_radio_group_padding"
-            android:textSize="20sp"
+            android:textAppearance="@style/TextAppearance.QS.DetailItemPrimary"
             android:text="@string/quick_settings_location_detail_mode_high_accuracy_title" />
         <RadioButton android:id="@+id/radio_battery_saving"
             android:layout_width="wrap_content"
@@ -58,7 +58,7 @@
             android:paddingLeft="@dimen/detail_radio_group_padding_left"
             android:paddingRight="@dimen/detail_radio_group_padding"
             android:paddingBottom="@dimen/detail_radio_group_padding"
-            android:textSize="20sp"
+            android:textAppearance="@style/TextAppearance.QS.DetailItemPrimary"
             android:text="@string/quick_settings_location_detail_mode_battery_saving_title" />
         <RadioButton android:id="@+id/radio_sensors_only"
             android:layout_width="wrap_content"
@@ -67,7 +67,7 @@
             android:paddingLeft="@dimen/detail_radio_group_padding_left"
             android:paddingRight="@dimen/detail_radio_group_padding"
             android:paddingBottom="@dimen/detail_radio_group_padding"
-            android:textSize="20sp"
+            android:textAppearance="@style/TextAppearance.QS.DetailItemPrimary"
             android:text="@string/quick_settings_location_detail_mode_sensors_only_title" />
         </RadioGroup>
     </LinearLayout>


### PR DESCRIPTION
Current text size of the radio buttons looks too large, use standard TextAppearance.

Change-Id: I5252118aa48ae306109ac4cb59bddbf7f6c67eff